### PR TITLE
내가 찾는 재능 게시물 목록 조회 구현

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/controller/PostController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/controller/PostController.java
@@ -4,11 +4,13 @@ import com.dpm.winwin.api.common.response.dto.BaseResponseDto;
 import com.dpm.winwin.api.post.dto.request.PostAddRequest;
 import com.dpm.winwin.api.post.dto.request.PostUpdateRequest;
 import com.dpm.winwin.api.post.dto.response.PostAddResponse;
+import com.dpm.winwin.api.post.dto.response.PostCustomizedListResponse;
 import com.dpm.winwin.api.post.dto.response.PostListResponse;
 import com.dpm.winwin.api.post.dto.response.PostMethodsResponse;
 import com.dpm.winwin.api.post.dto.response.PostReadResponse;
 import com.dpm.winwin.api.post.dto.response.PostUpdateResponse;
 import com.dpm.winwin.api.post.service.PostService;
+import com.dpm.winwin.domain.repository.post.dto.request.PostCustomizedConditionRequest;
 import com.dpm.winwin.domain.repository.post.dto.request.PostListConditionRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -40,13 +42,21 @@ public class PostController {
     return BaseResponseDto.ok(response);
   }
 
+  @GetMapping("/custom")
+  public BaseResponseDto<Page<PostCustomizedListResponse>> getCustomPostList(
+      PostCustomizedConditionRequest condition, Pageable pageable) {
+    Long tempMemberId = 1L;
+    Page<PostCustomizedListResponse> response = postService
+        .getPostsCustomized(tempMemberId, condition, pageable);
+    return BaseResponseDto.ok(response);
+  }
+
   @GetMapping("/{id}")
   public BaseResponseDto<PostReadResponse> getPost(@PathVariable Long id) {
     return BaseResponseDto.ok(postService.get(id));
   }
 
   @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
   public BaseResponseDto<PostAddResponse> createPost(
       @RequestHeader("memberId") final long memberId, @RequestBody final PostAddRequest request) {
     PostAddResponse response = postService.save(memberId, request);

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostCustomizedListResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostCustomizedListResponse.java
@@ -1,0 +1,27 @@
+package com.dpm.winwin.api.post.dto.response;
+
+import com.dpm.winwin.domain.entity.post.Post;
+
+public record PostCustomizedListResponse(
+    Long postId,
+    String title,
+    String subCategory,
+    Integer likes,
+    Long memberId,
+    String nickname,
+    String image,
+    String ranks
+) {
+
+    public static PostCustomizedListResponse of(Post post) {
+        return new PostCustomizedListResponse(
+            post.getId(),
+            post.getTitle(),
+            post.getSubCategory().getName(),
+            post.getLikes().size(),
+            post.getMember().getId(),
+            post.getMember().getNickname(),
+            post.getMember().getImage(),
+            post.getMember().getRanks().getName());
+    }
+}

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/service/PostService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/service/PostService.java
@@ -4,9 +4,11 @@ import com.dpm.winwin.api.common.error.enums.ErrorMessage;
 import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.post.dto.request.LinkRequest;
 import com.dpm.winwin.api.post.dto.request.PostAddRequest;
+import com.dpm.winwin.domain.repository.post.dto.request.PostCustomizedConditionRequest;
 import com.dpm.winwin.api.post.dto.request.PostUpdateRequest;
 import com.dpm.winwin.api.post.dto.response.LinkResponse;
 import com.dpm.winwin.api.post.dto.response.PostAddResponse;
+import com.dpm.winwin.api.post.dto.response.PostCustomizedListResponse;
 import com.dpm.winwin.api.post.dto.response.PostListResponse;
 import com.dpm.winwin.api.post.dto.response.PostMethodResponse;
 import com.dpm.winwin.api.post.dto.response.PostMethodsResponse;
@@ -52,6 +54,12 @@ public class PostService {
     public Page<PostListResponse> getPosts(PostListConditionRequest condition, Pageable pageable) {
         Page<Post> posts = postRepository.getAllByIsShareAndMidCategory(condition, pageable);
         return posts.map(PostListResponse::of);
+    }
+
+    public Page<PostCustomizedListResponse> getPostsCustomized(
+        Long memberId, PostCustomizedConditionRequest condition, Pageable pageable) {
+        Page<Post> posts = postRepository.getAllByMemberTalents(memberId, condition, pageable);
+        return posts.map(PostCustomizedListResponse::of);
     }
 
     public PostAddResponse save(long memberId, PostAddRequest request) {

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/talent/MemberTalent.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/talent/MemberTalent.java
@@ -1,6 +1,7 @@
 package com.dpm.winwin.domain.entity.talent;
 
 import com.dpm.winwin.domain.entity.BaseEntity;
+import com.dpm.winwin.domain.entity.category.SubCategory;
 import com.dpm.winwin.domain.entity.member.Member;
 import com.dpm.winwin.domain.entity.member.enums.TalentType;
 import lombok.AccessLevel;
@@ -33,7 +34,7 @@ public class MemberTalent extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "talent_id")
-    private Talent talent;
+    private SubCategory talent;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/post/CustomPostRepository.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/post/CustomPostRepository.java
@@ -1,6 +1,7 @@
 package com.dpm.winwin.domain.repository.post;
 
 import com.dpm.winwin.domain.entity.post.Post;
+import com.dpm.winwin.domain.repository.post.dto.request.PostCustomizedConditionRequest;
 import com.dpm.winwin.domain.repository.post.dto.request.PostListConditionRequest;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -11,6 +12,8 @@ public interface CustomPostRepository {
     Optional<Post> getPostByMemberId(Long memberId, Long postId);
 
     Page<Post> getAllByIsShareAndMidCategory(PostListConditionRequest condition, Pageable pageable);
+
+    Page<Post> getAllByMemberTalents(Long memberId, PostCustomizedConditionRequest condition, Pageable pageable);
 
     Optional<Post> getByIdFetchJoin(Long postId);
 }

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/post/dto/request/PostCustomizedConditionRequest.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/post/dto/request/PostCustomizedConditionRequest.java
@@ -1,0 +1,7 @@
+package com.dpm.winwin.domain.repository.post.dto.request;
+
+public record PostCustomizedConditionRequest(
+    Long subCategoryId
+) {
+
+}

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/post/impl/CustomPostRepositoryImpl.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/post/impl/CustomPostRepositoryImpl.java
@@ -7,9 +7,14 @@ import static com.dpm.winwin.domain.entity.link.QLink.link;
 import static com.dpm.winwin.domain.entity.member.QMember.member;
 import static com.dpm.winwin.domain.entity.post.QLikes.likes;
 import static com.dpm.winwin.domain.entity.post.QPost.post;
+import static com.dpm.winwin.domain.entity.talent.QMemberTalent.memberTalent;
 
+import com.dpm.winwin.domain.entity.category.SubCategory;
+import com.dpm.winwin.domain.entity.member.enums.TalentType;
 import com.dpm.winwin.domain.entity.post.Post;
+import com.dpm.winwin.domain.entity.talent.MemberTalent;
 import com.dpm.winwin.domain.repository.post.CustomPostRepository;
+import com.dpm.winwin.domain.repository.post.dto.request.PostCustomizedConditionRequest;
 import com.dpm.winwin.domain.repository.post.dto.request.PostListConditionRequest;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -84,6 +89,45 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .where(post.id.eq(postId))
                 .fetchOne()
         );
+    }
+
+    public Page<Post> getAllByMemberTalents(
+        Long memberId, PostCustomizedConditionRequest condition, Pageable pageable) {
+        List<SubCategory> subCategories = queryFactory.selectFrom(memberTalent)
+            .leftJoin(memberTalent.member, member).fetchJoin()
+            .where(
+                memberTalent.member.id.eq(memberId),
+                memberTalent.type.eq(TalentType.TAKE)
+            )
+            .fetch()
+            .stream().map(MemberTalent::getTalent)
+            .toList();
+
+        List<Post> posts = queryFactory.selectFrom(post)
+            .leftJoin(post.member, member).fetchJoin()
+            .leftJoin(post.likes, likes).fetchJoin()
+            .leftJoin(post.subCategory, subCategory).fetchJoin()
+            .where(
+                member.id.eq(memberId).not(),
+                post.subCategory.in(subCategories),
+                subCategoryEq(condition.subCategoryId())
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory.select(post.count())
+            .from(post)
+            .leftJoin(post.member, member)
+            .leftJoin(post.likes, likes)
+            .leftJoin(post.subCategory, subCategory)
+            .where(
+                member.id.eq(memberId).not(),
+                post.subCategory.in(subCategories),
+                subCategoryEq(condition.subCategoryId())
+            );
+
+        return PageableExecutionUtils.getPage(posts, pageable, countQuery::fetchOne);
     }
 
     private BooleanExpression isShareEq(Boolean isShare) {


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 내가 찾는 재능 게시물 목록 조회 api 구현

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
회원의 MemberTalent의 SubCategory 리스트를 게시물의 카테고리로 가지고 있는 게시물 목록을 조회해주었습니다.
페이징 처리를 최적화하기 위해 PageableExecutionUtils.getPage()를 사용하여 맨 첫 페이지 content 개수가 size 미달이거나, 마지막 page인 경우 count query가 실행하지 않도록 해주었습니다.

**궁금한 점**

1. post을 조회하는 코드와 post의 수를 계산하는 코드에서 fetchjoin 부분을 똑같이 두고 작성하였는데, 두번째 경우에서만 fetchjoin이 되지 않는다는 오류가 뜹니다. post 개수만 계산해주면 되기 때문에 굳이 fetchjoin을 사용하지 않아도 될 것이라 판단되어 그냥 조인으로 변경해주었지만, 오류가 발생하는 정확한 이유가 궁금하여 여쭤봅니다.
제가 찾아본 바로는 엔티티가 아닌 dto나 엔티티의 count를 조회하는 것은 fetchjoin 자체가 불가한 것 같기도 한데, 제가 이해한 것이 맞는지 팀원분들의 의견이 궁금합니다😀
[참고한 영한님 의견](https://www.inflearn.com/questions/23847/queryprojection%EA%B3%BC-fetch-join)
```java
List<Post> posts = queryFactory.selectFrom(post)
            .leftJoin(post.member, member).fetchJoin()
            .leftJoin(post.likes, likes).fetchJoin()
            .leftJoin(post.subCategory, subCategory).fetchJoin()
            .where(
                member.id.eq(memberId).not(),
                post.subCategory.in(subCategories),
                subCategoryEq(condition.subCategoryId())
            )
            .offset(pageable.getOffset())
            .limit(pageable.getPageSize())
            .fetch();

        JPAQuery<Long> countQuery = queryFactory.select(post.count())
            .from(post)
            .leftJoin(post.member, member)
            .leftJoin(post.likes, likes)
            .leftJoin(post.subCategory, subCategory)
            .where(
                member.id.eq(memberId).not(),
                post.subCategory.in(subCategories),
                subCategoryEq(condition.subCategoryId())
            );

```

2. 또한, 구현한 페이징 처리 방법이 적절한지에 대해서도 의견 주시면 감사하겠습니다! 😀
