### PR TITLE
페이지 응답 값 Generic type 적용

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/common/response/dto/GlobalPageResponseDto.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/common/response/dto/GlobalPageResponseDto.java
@@ -1,22 +1,21 @@
-package com.dpm.winwin.api.post.dto.response;
+package com.dpm.winwin.api.common.response.dto;
 
 import java.util.List;
 import org.springframework.data.domain.Page;
 
-public record PostCustomizedListResponse(
-    List<PostCustomizedResponse> content,
+public record GlobalPageResponseDto<T>(
+    List<T> content,
     long totalElements,
     int totalPages,
     boolean hasNextPages
 ) {
 
-    public static PostCustomizedListResponse of(Page page) {
-        return new PostCustomizedListResponse(
+    public static <T> GlobalPageResponseDto<T> of(Page<T> page) {
+        return new GlobalPageResponseDto<T>(
             page.getContent(),
             page.getTotalElements(),
             page.getTotalPages(),
             page.hasNext()
         );
     }
-
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/controller/PostController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/controller/PostController.java
@@ -4,7 +4,8 @@ import com.dpm.winwin.api.common.response.dto.BaseResponseDto;
 import com.dpm.winwin.api.post.dto.request.PostAddRequest;
 import com.dpm.winwin.api.post.dto.request.PostUpdateRequest;
 import com.dpm.winwin.api.post.dto.response.PostAddResponse;
-import com.dpm.winwin.api.post.dto.response.PostCustomizedListResponse;
+import com.dpm.winwin.api.common.response.dto.GlobalPageResponseDto;
+import com.dpm.winwin.api.post.dto.response.PostCustomizedResponse;
 import com.dpm.winwin.api.post.dto.response.PostListResponse;
 import com.dpm.winwin.api.post.dto.response.PostMethodsResponse;
 import com.dpm.winwin.api.post.dto.response.PostReadResponse;
@@ -13,7 +14,6 @@ import com.dpm.winwin.api.post.service.PostService;
 import com.dpm.winwin.domain.repository.post.dto.request.PostCustomizedConditionRequest;
 import com.dpm.winwin.domain.repository.post.dto.request.PostListConditionRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,18 +33,18 @@ public class PostController {
   private final PostService postService;
 
   @GetMapping
-  public BaseResponseDto<Page<PostListResponse>> getPostList(
+  public BaseResponseDto<GlobalPageResponseDto<PostListResponse>> getPostList(
       PostListConditionRequest condition, Pageable pageable
   ) {
-    Page<PostListResponse> response = postService.getPosts(condition, pageable);
+    GlobalPageResponseDto<PostListResponse> response = postService.getPosts(condition, pageable);
     return BaseResponseDto.ok(response);
   }
 
   @GetMapping("/custom")
-  public BaseResponseDto<PostCustomizedListResponse> getCustomPostList(
+  public BaseResponseDto<GlobalPageResponseDto<PostCustomizedResponse>> getCustomPostList(
       PostCustomizedConditionRequest condition, Pageable pageable) {
     Long tempMemberId = 1L;
-    PostCustomizedListResponse response = postService
+    GlobalPageResponseDto<PostCustomizedResponse> response = postService
         .getPostsCustomized(tempMemberId, condition, pageable);
     return BaseResponseDto.ok(response);
   }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/service/PostService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/service/PostService.java
@@ -5,9 +5,9 @@ import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.post.dto.request.LinkRequest;
 import com.dpm.winwin.api.post.dto.request.PostAddRequest;
 import com.dpm.winwin.api.post.dto.request.PostUpdateRequest;
+import com.dpm.winwin.api.common.response.dto.GlobalPageResponseDto;
 import com.dpm.winwin.api.post.dto.response.LinkResponse;
 import com.dpm.winwin.api.post.dto.response.PostAddResponse;
-import com.dpm.winwin.api.post.dto.response.PostCustomizedListResponse;
 import com.dpm.winwin.api.post.dto.response.PostCustomizedResponse;
 import com.dpm.winwin.api.post.dto.response.PostListResponse;
 import com.dpm.winwin.api.post.dto.response.PostMethodResponse;
@@ -52,17 +52,19 @@ public class PostService {
     private final PostRepository postRepository;
     private final LinkRepository linkRepository;
 
-    public Page<PostListResponse> getPosts(PostListConditionRequest condition, Pageable pageable) {
-        Page<Post> posts = postRepository.getAllByIsShareAndMidCategory(condition, pageable);
-        return posts.map(PostListResponse::of);
+    public GlobalPageResponseDto<PostListResponse> getPosts(PostListConditionRequest condition, Pageable pageable) {
+        Page<PostListResponse> page = postRepository
+            .getAllByIsShareAndMidCategory(condition, pageable)
+            .map(PostListResponse::of);
+        return GlobalPageResponseDto.of(page);
     }
 
-    public PostCustomizedListResponse getPostsCustomized(
+    public GlobalPageResponseDto<PostCustomizedResponse> getPostsCustomized(
         Long memberId, PostCustomizedConditionRequest condition, Pageable pageable) {
         Page<PostCustomizedResponse> page = postRepository
             .getAllByMemberTalents(memberId, condition, pageable)
             .map(PostCustomizedResponse::of);
-        return PostCustomizedListResponse.of(page);
+        return GlobalPageResponseDto.of(page);
     }
 
     public PostAddResponse save(long memberId, PostAddRequest request) {


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 제네릭 타입의 페이지 공통 응답 값 생성
- 기존 API에 적용 (게시물 목록 조회, 맞춤 게시물 목록 조회)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
