### PR TITLE
닉네임 검증 로직 적용

### DIFF
--- a/winwin-be-api/build.gradle
+++ b/winwin-be-api/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/common/error/enums/ErrorMessage.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/common/error/enums/ErrorMessage.java
@@ -24,6 +24,7 @@ public enum ErrorMessage {
     INVALID_ISSUER_VALUE(BAD_REQUEST, "ISSUER 값이 잘못되었습니다."),
     INVALID_CLIENT_ID(BAD_REQUEST, "클라이언트 아이디가 잘못되었습니다."),
     APPLE_TOKEN_GENERATE_FAIL(BAD_REQUEST, "잘못된 액세스 토큰입니다."),
+    INVALID_NICKNAME(BAD_REQUEST, "닉네임 입력이 올바르지 않습니다."),
 
     LOGIN_CANCEL(UNAUTHORIZED, "사용자가 로그인을 취소하였습니다.");
 

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/common/response/dto/BaseResponseDto.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/common/response/dto/BaseResponseDto.java
@@ -5,4 +5,7 @@ public record BaseResponseDto<T>(String message, T data) {
     public static <T> BaseResponseDto<T> ok(T data){
         return new BaseResponseDto<>("success",data);
     }
+    public static <T> BaseResponseDto<T> error(T data){
+        return new BaseResponseDto<>("error",data);
+    }
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
     @PatchMapping("/nickname")
     public BaseResponseDto<MemberNicknameResponse> updateMemberNickname(
             @Valid @RequestBody MemberNicknameRequest memberNicknameRequest, BindingResult bindingResult){
-        Long memberId = 1L; //임시로 특정 회원 고정
+        Long memberId = 1L;
         if (bindingResult.hasErrors()){
             throw new BusinessException(INVALID_NICKNAME);
         }
@@ -49,10 +49,10 @@ public class MemberController {
         return BaseResponseDto.ok(memberQueryService.readMemberInfo(memberId));
     }
 
-    @PutMapping("/{memberId}")
+    @PutMapping
     public BaseResponseDto<MemberUpdateResponse> updateMember(
-            @PathVariable Long memberId,
             @RequestBody final  MemberUpdateRequest memberUpdateRequest) {
+        Long memberId = 1L;
         return BaseResponseDto.ok(memberCommandService.updateMember(memberId, memberUpdateRequest));
     }
 

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
 
-    @PutMapping("/nickname")
+    @PatchMapping("/nickname")
     public BaseResponseDto<String> updateMemberNickname(
             @Validated @RequestBody MemberNicknameRequest memberNicknameRequest, BindingResult bindingResult){
         Long memberId = 1L; //임시로 특정 회원 고정

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -9,6 +9,8 @@ import com.dpm.winwin.api.member.service.MemberCommandService;
 import com.dpm.winwin.api.member.service.MemberQueryService;
 import com.dpm.winwin.domain.repository.member.dto.request.MemberNicknameRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -27,11 +29,13 @@ public class MemberController {
     private final MemberCommandService memberCommandService;
 
     @PutMapping("/nickname")
-    public BaseResponseDto<Long> updateMemberNickname(
-            @RequestBody MemberNicknameRequest memberNicknameRequest){
+    public BaseResponseDto<String> updateMemberNickname(
+            @Validated @RequestBody MemberNicknameRequest memberNicknameRequest, BindingResult bindingResult){
         Long memberId = 1L; //임시로 특정 회원 고정
-        Long id = memberCommandService.updateMemberNickname(memberId, memberNicknameRequest);
-        return BaseResponseDto.ok(id);
+        if (bindingResult.hasErrors()){
+            return BaseResponseDto.error(bindingResult.getFieldError().getDefaultMessage());
+        }
+        return BaseResponseDto.ok(memberCommandService.updateMemberNickname(memberId, memberNicknameRequest));
     }
 
     @GetMapping("/{memberId}")

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.dpm.winwin.api.member.controller;
 
+import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.common.response.dto.BaseResponseDto;
 import com.dpm.winwin.api.member.dto.request.MemberUpdateRequest;
+import com.dpm.winwin.api.member.dto.response.MemberNicknameResponse;
 import com.dpm.winwin.api.member.dto.response.MemberRankReadResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateResponse;
 import com.dpm.winwin.api.member.dto.response.RanksListResponse;
@@ -10,7 +12,6 @@ import com.dpm.winwin.api.member.service.MemberQueryService;
 import com.dpm.winwin.domain.repository.member.dto.request.MemberNicknameRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -19,6 +20,10 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.dpm.winwin.api.common.error.enums.ErrorMessage.INVALID_NICKNAME;
 
 
 @RequiredArgsConstructor
@@ -29,11 +34,11 @@ public class MemberController {
     private final MemberCommandService memberCommandService;
 
     @PatchMapping("/nickname")
-    public BaseResponseDto<String> updateMemberNickname(
-            @Validated @RequestBody MemberNicknameRequest memberNicknameRequest, BindingResult bindingResult){
+    public BaseResponseDto<MemberNicknameResponse> updateMemberNickname(
+            @Valid @RequestBody MemberNicknameRequest memberNicknameRequest, BindingResult bindingResult){
         Long memberId = 1L; //임시로 특정 회원 고정
         if (bindingResult.hasErrors()){
-            return BaseResponseDto.error(bindingResult.getFieldError().getDefaultMessage());
+            throw new BusinessException(INVALID_NICKNAME);
         }
         return BaseResponseDto.ok(memberCommandService.updateMemberNickname(memberId, memberNicknameRequest));
     }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberNicknameResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberNicknameResponse.java
@@ -1,0 +1,4 @@
+package com.dpm.winwin.api.member.dto.response;
+
+public record MemberNicknameResponse(String nickname) {
+}

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberRankReadResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberRankReadResponse.java
@@ -7,9 +7,9 @@ public record MemberRankReadResponse(
         String nickname,
         String image,
         String introduction,
-        String rankName,
-        String rankImage,
-        Integer rankLikeCount,
+        String ranks,
+        String ranksImage,
+        Integer likeCount,
         String profileLink,
         List<String> givenTalents,
         List<String> takenTalents

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -2,6 +2,7 @@ package com.dpm.winwin.api.member.service;
 
 import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.member.dto.request.MemberUpdateRequest;
+import com.dpm.winwin.api.member.dto.response.MemberNicknameResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateResponse;
 import com.dpm.winwin.domain.entity.category.SubCategory;
 import com.dpm.winwin.domain.entity.member.Member;
@@ -25,12 +26,12 @@ public class MemberCommandService {
     private final MemberRepository memberRepository;
     private final SubCategoryRepository subCategoryRepository;
 
-    public String updateMemberNickname(Long memberId,
-                                     MemberNicknameRequest memberNicknameRequest) {
+    public MemberNicknameResponse updateMemberNickname(Long memberId,
+                                                       MemberNicknameRequest memberNicknameRequest) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
         member.updateNickname(memberNicknameRequest.nickname());
-        return member.getNickname();
+        return new MemberNicknameResponse(member.getNickname());
     }
 
     public MemberUpdateResponse updateMember(Long memberId,

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -25,12 +25,12 @@ public class MemberCommandService {
     private final MemberRepository memberRepository;
     private final SubCategoryRepository subCategoryRepository;
 
-    public Long updateMemberNickname(Long memberId,
+    public String updateMemberNickname(Long memberId,
                                      MemberNicknameRequest memberNicknameRequest) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
         member.updateNickname(memberNicknameRequest.nickname());
-        return member.getId();
+        return member.getNickname();
     }
 
     public MemberUpdateResponse updateMember(Long memberId,

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberQueryService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberQueryService.java
@@ -34,7 +34,7 @@ public class MemberQueryService {
         MemberReadResponse memberReadResponse =  memberRepository.readMemberInfo(memberId)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
 
-        Integer likeCount = member.getTotalPostLikes();
+        Integer likeCount = member.getLikeCount();
         if (likeCount == null)
             likeCount = 0;
 

--- a/winwin-be-domain/build.gradle
+++ b/winwin-be-domain/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 def querydslDir = "src/main/generated/querydsl"

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/member/Member.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/member/Member.java
@@ -65,7 +65,7 @@ public class Member extends BaseEntity{
     @Column(nullable = false)
     private Ranks ranks;
 
-    private Integer totalPostLikes;
+    private Integer likeCount;
 
     private String provider;
 
@@ -132,8 +132,8 @@ public class Member extends BaseEntity{
     }
 
     public void updateTotalPostLike(){
-        this.totalPostLikes += 1;
-        updateRank(this.totalPostLikes);
+        this.likeCount += 1;
+        updateRank(this.likeCount);
     }
 
     private void updateRank(Integer likesCount){

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/dto/request/MemberNicknameRequest.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/dto/request/MemberNicknameRequest.java
@@ -1,4 +1,12 @@
 package com.dpm.winwin.domain.repository.member.dto.request;
 
-public record MemberNicknameRequest(String nickname) {
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+
+public record MemberNicknameRequest(
+        @NotEmpty(message = "닉네임은 필수 입력값입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z\\s]{2,10}$" , message = "닉네임은 한글과 영어만 가능하며, 2~10자리여야 합니다.")
+        String nickname
+) {
+
 }

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/dto/request/MemberNicknameRequest.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/dto/request/MemberNicknameRequest.java
@@ -4,8 +4,8 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
 public record MemberNicknameRequest(
-        @NotEmpty(message = "닉네임은 필수 입력값입니다.")
-        @Pattern(regexp = "^[가-힣a-zA-Z\\s]{2,10}$" , message = "닉네임은 한글과 영어만 가능하며, 2~10자리여야 합니다.")
+        @NotEmpty
+        @Pattern(regexp = "^[가-힣a-zA-Z\\s]{2,10}$")
         String nickname
 ) {
 


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 닉네임 설정 시 공백 포함 2~10자, 한글과 영어만 존재하는 것에 대한 검증을 구현하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- BaseResponseDto에 error를 추가하였는데 원래 잘못된 닉네임이 입력되었을 때, 이렇게 반환하는 것이 맞는지 궁금합니다!