### PR TITLE
test : 회원 탈퇴 restdocs 테스트 작성

### DIFF
--- a/winwin-be-api/src/docs/asciidoc/member-api.adoc
+++ b/winwin-be-api/src/docs/asciidoc/member-api.adoc
@@ -27,3 +27,7 @@ operation::member-controller-test/member의_profile-image를_수정한다[snippe
 [[등급-목록-조회]]
 == 등급 목록 조회
 operation::member-controller-test/rank_목록을_조회한다[snippets='http-request,http-response,response-fields']
+
+[[회원-탈퇴]]
+== 회원 탈퇴
+operation::member-controller-test/회원_탈퇴[snippets='http-request,http-response,response-fields']

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import static com.dpm.winwin.api.common.utils.SecurityUtil.getCurrentMemberId;
 
 import com.dpm.winwin.api.common.response.dto.BaseResponseDto;
 import com.dpm.winwin.api.member.dto.request.MemberUpdateRequest;
+import com.dpm.winwin.api.member.dto.response.MemberDeleteResponse;
 import com.dpm.winwin.api.member.dto.response.MemberNicknameResponse;
 import com.dpm.winwin.api.member.dto.response.MemberRankReadResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateImageResponse;
@@ -75,9 +76,9 @@ public class MemberController {
         return BaseResponseDto.ok(response);
     }
 
-    @DeleteMapping("/{memberId}")
-    public BaseResponseDto<Long> deleteMember(@PathVariable Long memberId) {
-        Long deleteMemberId = memberCommandService.deleteMember(memberId);
-        return BaseResponseDto.ok(deleteMemberId);
+    @DeleteMapping("/me")
+    public BaseResponseDto<MemberDeleteResponse> deleteMember(@AuthenticationPrincipal User user) {
+        MemberDeleteResponse memberDeleteResponse = memberCommandService.deleteMember(Long.parseLong(user.getUsername()));
+        return BaseResponseDto.ok(memberDeleteResponse);
     }
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberDeleteResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberDeleteResponse.java
@@ -1,0 +1,5 @@
+package com.dpm.winwin.api.member.dto.response;
+
+public record MemberDeleteResponse(Long deleteMemberId) {
+
+}

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -2,15 +2,15 @@ package com.dpm.winwin.api.member.service;
 
 import static com.dpm.winwin.api.common.constant.ImageType.PROFILE_IMAGE;
 import static com.dpm.winwin.api.common.error.enums.ErrorMessage.APPLE_TOKEN_REVOKE_FAIL;
-import static com.dpm.winwin.api.common.error.enums.ErrorMessage.DOES_NOT_MATCH_MEMBER_ID;
 import static com.dpm.winwin.api.common.error.enums.ErrorMessage.MEMBER_NOT_FOUND;
 import static com.dpm.winwin.domain.entity.member.enums.TalentType.GIVE;
 import static com.dpm.winwin.domain.entity.member.enums.TalentType.TAKE;
 
 import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.common.file.service.FileService;
-import com.dpm.winwin.api.jwt.TokenProvider;
+import com.dpm.winwin.api.member.dto.request.MemberNicknameRequest;
 import com.dpm.winwin.api.member.dto.request.MemberUpdateRequest;
+import com.dpm.winwin.api.member.dto.response.MemberDeleteResponse;
 import com.dpm.winwin.api.member.dto.response.MemberNicknameResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateImageResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateResponse;
@@ -19,19 +19,13 @@ import com.dpm.winwin.domain.entity.member.Member;
 import com.dpm.winwin.domain.entity.oauth.OauthToken;
 import com.dpm.winwin.domain.repository.category.SubCategoryRepository;
 import com.dpm.winwin.domain.repository.member.MemberRepository;
-import com.dpm.winwin.api.member.dto.request.MemberNicknameRequest;
-import com.dpm.winwin.domain.repository.oauth.OauthRepository;
-import io.jsonwebtoken.Claims;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.stereotype.Service;
@@ -49,12 +43,9 @@ public class MemberCommandService {
     private static final String TOKEN_TYPE_HINT = "refresh_token";
     private final MemberRepository memberRepository;
     private final SubCategoryRepository subCategoryRepository;
-    private final OauthRepository oauthRepository;
     private final RestTemplate restTemplate;
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final FileService fileService;
-
-    private final TokenProvider tokenProvider;
 
     public MemberNicknameResponse updateMemberNickname(Long memberId,
                                                        MemberNicknameRequest memberNicknameRequest) {
@@ -101,12 +92,10 @@ public class MemberCommandService {
         );
     }
 
-    public Long deleteMember(Long memberId) {
+    public MemberDeleteResponse deleteMember(Long memberId) {
 
         Member member = memberRepository.findMemberWithToken(memberId)
             .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
-
-        verifyMemberId(memberId);
 
         OauthToken oauthToken = member.getOauthToken();
         String refreshToken = oauthToken.getRefreshToken();
@@ -115,26 +104,12 @@ public class MemberCommandService {
 
         if (response.getStatusCode().equals(HttpStatus.OK)) {
             memberRepository.delete(member);
-            return memberId;
+
+            MemberDeleteResponse memberDeleteResponse = new MemberDeleteResponse(memberId);
+            return memberDeleteResponse;
         }
 
         throw new BusinessException(APPLE_TOKEN_REVOKE_FAIL);
-    }
-
-    private void verifyMemberId(Long memberId) {
-        Long jwtMemberId = getJwtMemberId();
-
-        if (!Objects.equals(jwtMemberId, memberId)) {
-            throw new BusinessException(DOES_NOT_MATCH_MEMBER_ID);
-        }
-    }
-
-    private Long getJwtMemberId() {
-        UsernamePasswordAuthenticationToken authentication = (UsernamePasswordAuthenticationToken) SecurityContextHolder.getContext()
-            .getAuthentication();
-        String jwt = (String) authentication.getCredentials();
-        Claims claims = tokenProvider.getClaims(jwt);
-        return (Long) claims.get("memberId");
     }
 
     private ResponseEntity<Object> appleTokenRevokeRequest(String providerName, String refreshToken) {

--- a/winwin-be-api/src/test/java/com/dpm/winwin/api/member/controller/MemberControllerTest.java
+++ b/winwin-be-api/src/test/java/com/dpm/winwin/api/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.dpm.winwin.api.member.controller;
 
+import com.dpm.winwin.api.member.dto.response.MemberDeleteResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateImageResponse;
 import com.dpm.winwin.api.member.dto.response.RanksListResponse;
 import com.dpm.winwin.api.member.dto.response.RanksResponse;
@@ -25,6 +26,7 @@ import static com.dpm.winwin.api.member.controller.MemberControllerTest.MEMBER_I
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
@@ -280,5 +282,30 @@ public class MemberControllerTest extends RestDocsTestSupport {
                 )
             ))
         ;
+    }
+
+    @Test
+    void 회원_탈퇴() throws Exception {
+
+        // Given
+        Long deleteMemberId = Long.valueOf(MEMBER_ID);
+        MemberDeleteResponse memberDeleteResponse = new MemberDeleteResponse(deleteMemberId);
+        given(memberCommandService.deleteMember(deleteMemberId)).willReturn(memberDeleteResponse);
+
+        // Then
+        ResultActions resultActions = mockMvc.perform(
+            delete("/api/v1/members/me")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("성공 여부"),
+                    fieldWithPath("data.deleteMemberId").type(JsonFieldType.NUMBER).description("탈퇴한 회원 아이디")
+                )
+            ));
     }
 }


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 회원 탈퇴 restdocs용 테스트 코드 작성했습니다.
- 기존 /api/v1/member/{memberId} => /api/v1/member/me 로 api url 변경했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
