### PR TITLE
좋아요 수 string 포맷 변경

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/MyPagePostResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/MyPagePostResponse.java
@@ -1,18 +1,27 @@
 package com.dpm.winwin.api.post.dto.response;
 
+import static com.dpm.winwin.domain.entity.post.Likes.changeFormatCountToString;
+
 import com.dpm.winwin.domain.dto.post.MyPagePostDto;
 import java.util.List;
 
-public record MyPagePostResponse(Long id,
-                                 String title,
-                                 String subCategory,
-                                 boolean isShare,
-                                 List<String> takenTalents,
-                                 int likes) {
+public record MyPagePostResponse(
+    Long id,
+    String title,
+    String subCategory,
+    boolean isShare,
+    List<String> takenTalents,
+    String likes
+) {
 
     public static MyPagePostResponse of(MyPagePostDto myPagePostDto) {
-        return new MyPagePostResponse(myPagePostDto.id(), myPagePostDto.title(),
-            myPagePostDto.subCategory(), myPagePostDto.isShare(), myPagePostDto.takenTalents(),
-            myPagePostDto.likes());
+        return new MyPagePostResponse(
+            myPagePostDto.id(),
+            myPagePostDto.title(),
+            myPagePostDto.subCategory(),
+            myPagePostDto.isShare(),
+            myPagePostDto.takenTalents(),
+            changeFormatCountToString(myPagePostDto.likes())
+        );
     }
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostCustomizedResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostCustomizedResponse.java
@@ -1,5 +1,7 @@
 package com.dpm.winwin.api.post.dto.response;
 
+import static com.dpm.winwin.domain.entity.post.Likes.changeFormatCountToString;
+
 import com.dpm.winwin.domain.entity.post.Post;
 
 public record PostCustomizedResponse(
@@ -7,7 +9,7 @@ public record PostCustomizedResponse(
     String title,
     String subCategory,
     boolean isShare,
-    Integer likes,
+    String likes,
     Long memberId,
     String nickname,
     String image,
@@ -20,7 +22,7 @@ public record PostCustomizedResponse(
             post.getTitle(),
             post.getSubCategory().getName(),
             post.isShare(),
-            post.getLikes().size(),
+            changeFormatCountToString(post.getLikes().size()),
             post.getMember().getId(),
             post.getMember().getNickname(),
             post.getMember().getImage(),

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostReadResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostReadResponse.java
@@ -1,28 +1,32 @@
 package com.dpm.winwin.api.post.dto.response;
 
+import static com.dpm.winwin.domain.entity.post.Likes.changeFormatCountToString;
+
 import com.dpm.winwin.domain.entity.post.enums.ExchangePeriod;
 import com.dpm.winwin.domain.entity.post.enums.ExchangeTime;
 import com.dpm.winwin.domain.entity.post.enums.ExchangeType;
 import java.util.List;
 
-public record PostReadResponse(Long id,
-                               String title,
-                               String content,
-                               boolean isShare,
-                               String subCategory,
-                               List<LinkResponse> links,
-                               String chatLink,
-                               int likes,
-                               String takenContent,
-                               List<String> takenTalents,
-                               ExchangeType exchangeType,
-                               ExchangePeriod exchangePeriod,
-                               ExchangeTime exchangeTime,
-                               Long memberId,
-                               String nickname,
-                               String image,
-                               String ranks,
-                               Boolean isLike) {
+public record PostReadResponse(
+    Long id,
+    String title,
+    String content,
+    boolean isShare,
+    String subCategory,
+    List<LinkResponse> links,
+    String chatLink,
+    String likes,
+    String takenContent,
+    List<String> takenTalents,
+    ExchangeType exchangeType,
+    ExchangePeriod exchangePeriod,
+    ExchangeTime exchangeTime,
+    Long memberId,
+    String nickname,
+    String image,
+    String ranks,
+    Boolean isLike
+) {
 
     public static PostReadResponse from(
         Long id,
@@ -51,7 +55,7 @@ public record PostReadResponse(Long id,
             subCategory,
             links,
             chatLink,
-            likes,
+            changeFormatCountToString(likes),
             takenContent,
             takenTalents,
             exchangeType,

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/dto/response/PostResponse.java
@@ -1,5 +1,7 @@
 package com.dpm.winwin.api.post.dto.response;
 
+import static com.dpm.winwin.domain.entity.post.Likes.changeFormatCountToString;
+
 import com.dpm.winwin.domain.entity.post.Post;
 import java.util.List;
 
@@ -8,7 +10,7 @@ public record PostResponse(
     String title,
     String subCategory,
     boolean isShare,
-    Integer likes,
+    String likes,
     Long memberId,
     String nickname,
     String image,
@@ -22,7 +24,7 @@ public record PostResponse(
             post.getTitle(),
             post.getSubCategory().getName(),
             post.isShare(),
-            post.getLikes().size(),
+            changeFormatCountToString(post.getLikes().size()),
             post.getMember().getId(),
             post.getMember().getNickname(),
             post.getMember().getImage(),

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/post/service/LikesService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/post/service/LikesService.java
@@ -5,7 +5,6 @@ import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.post.dto.request.LikeAddRequest;
 import com.dpm.winwin.api.post.dto.response.LikesResponse;
 import com.dpm.winwin.domain.entity.member.Member;
-import com.dpm.winwin.domain.entity.post.Likes;
 import com.dpm.winwin.domain.entity.post.Post;
 import com.dpm.winwin.domain.repository.member.MemberRepository;
 import com.dpm.winwin.domain.repository.post.LikesRepository;

--- a/winwin-be-api/src/test/java/com/dpm/winwin/api/post/controller/PostControllerTest.java
+++ b/winwin-be-api/src/test/java/com/dpm/winwin/api/post/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.dpm.winwin.api.post.controller;
 
 import static com.dpm.winwin.api.utils.RestDocsConfig.field;
+import static com.dpm.winwin.domain.entity.post.Likes.changeFormatCountToString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -94,7 +95,7 @@ class PostControllerTest extends RestDocsTestSupport {
                     fieldWithPath("data.content[].title").type(JsonFieldType.STRING).description("게시물 제목"),
                     fieldWithPath("data.content[].subCategory").type(JsonFieldType.STRING).description("소분류 카테고리 이름"),
                     fieldWithPath("data.content[].isShare").type(JsonFieldType.BOOLEAN).description("재능 나눔 여부"),
-                    fieldWithPath("data.content[].likes").type(JsonFieldType.NUMBER).description("게시물 좋아요 수"),
+                    fieldWithPath("data.content[].likes").type(JsonFieldType.STRING).description("게시물 좋아요 수"),
                     fieldWithPath("data.content[].memberId").type(JsonFieldType.NUMBER).description("작성자 id"),
                     fieldWithPath("data.content[].nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
                     fieldWithPath("data.content[].image").type(JsonFieldType.STRING).description("작성자 이미지 url"),
@@ -146,7 +147,7 @@ class PostControllerTest extends RestDocsTestSupport {
                     fieldWithPath("data.content[].title").type(JsonFieldType.STRING).description("게시물 제목"),
                     fieldWithPath("data.content[].subCategory").type(JsonFieldType.STRING).description("소분류 카테고리 이름"),
                     fieldWithPath("data.content[].isShare").type(JsonFieldType.BOOLEAN).description("재능 나눔 여부"),
-                    fieldWithPath("data.content[].likes").type(JsonFieldType.NUMBER).description("게시물 좋아요 수"),
+                    fieldWithPath("data.content[].likes").type(JsonFieldType.STRING).description("게시물 좋아요 수"),
                     fieldWithPath("data.content[].memberId").type(JsonFieldType.NUMBER).description("작성자 id"),
                     fieldWithPath("data.content[].nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
                     fieldWithPath("data.content[].image").type(JsonFieldType.STRING).description("작성자 이미지 url"),
@@ -305,7 +306,7 @@ class PostControllerTest extends RestDocsTestSupport {
                 "제목" + i,
                 "UX/UI 디자인",
                 false,
-                3,
+                changeFormatCountToString(1234),
                 1L,
                 "말하는 감자" + i,
                 "https://dpm-pingpong-bucket.s3.ap-northeast-2.amazonaws.com/profileImage/3d4395e461db40108104200e286870c4-kirby.png",
@@ -325,7 +326,7 @@ class PostControllerTest extends RestDocsTestSupport {
                 "제목" + i,
                 "UX/UI 디자인",
                 false,
-                3,
+                changeFormatCountToString(1234),
                 1L,
                 "말하는 감자" + i,
                 "https://dpm-pingpong-bucket.s3.ap-northeast-2.amazonaws.com/profileImage/3d4395e461db40108104200e286870c4-kirby.png",
@@ -476,7 +477,7 @@ class PostControllerTest extends RestDocsTestSupport {
             List.of(new LinkResponse(1L, "www.naver.com"),
                 new LinkResponse(2L, "www.google.com")),
             "www.chatLink.com",
-            3,
+            changeFormatCountToString(1234),
             "받고 싶은 재능 내용",
             List.of("액세서리 · 패션소품", "뜨개 · 자수 · 라탄"),
             ExchangeType.ANY_TYPE,
@@ -545,7 +546,7 @@ class PostControllerTest extends RestDocsTestSupport {
                         .description("등급"),
                     fieldWithPath("data.isLike").type(JsonFieldType.BOOLEAN)
                         .description("해당 회원의 게시글 좋아요 여부"),
-                    fieldWithPath("data.likes").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data.likes").type(JsonFieldType.STRING)
                         .description("좋아요 수")
                 )
             ));
@@ -555,9 +556,9 @@ class PostControllerTest extends RestDocsTestSupport {
     void 회원별_post_목록을_조회한다() throws Exception {
 
         MyPagePostResponse response1 = new MyPagePostResponse(1L, "미술 나눔해요", "미술", false,
-            List.of("네일아트", "종이접기"), 149392);
+            List.of("네일아트", "종이접기"), changeFormatCountToString(1234));
         MyPagePostResponse response2 = new MyPagePostResponse(1L, "컴공 나눔해요", "개발", false,
-            List.of("Java", "node.js"), 1);
+            List.of("Java", "node.js"), changeFormatCountToString(1));
 
         PageImpl<MyPagePostResponse> myPagePostResponses = new PageImpl<>(
             List.of(response1, response2));
@@ -593,7 +594,7 @@ class PostControllerTest extends RestDocsTestSupport {
                         .description("소분류 카테고리 이름"),
                     fieldWithPath("data.content[].takenTalents").type(JsonFieldType.ARRAY).optional()
                         .description("받고 싶은 재능"),
-                    fieldWithPath("data.content[].likes").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data.content[].likes").type(JsonFieldType.STRING)
                         .description("게시물 좋아요 수"),
                     fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER)
                         .description("전체 데이터 수"),

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/dto/post/MyPagePostDto.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/dto/post/MyPagePostDto.java
@@ -3,13 +3,13 @@ package com.dpm.winwin.domain.dto.post;
 import com.querydsl.core.annotations.QueryProjection;
 import java.util.List;
 
-public record MyPagePostDto(Long id,
-                            String title,
-                            String subCategory,
-                            boolean isShare,
-                            List<String> takenTalents,
-                            int likes) {
-
+public record MyPagePostDto(
+    Long id,
+    String title,
+    String subCategory,
+    boolean isShare,
+    List<String> takenTalents,
+    int likes) {
 
     @QueryProjection
     public MyPagePostDto {

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/post/Likes.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/post/Likes.java
@@ -39,4 +39,12 @@ public class Likes extends BaseEntity {
         this.post = post;
     }
 
+    public static String changeFormatCountToString(int likeCount) {
+        if (likeCount >= 1000) {
+            double kCount = likeCount / 1000.0;
+            return String.valueOf(Math.floor(kCount * 10) / 10.0)
+                .replace(".0", "") + "k";
+        }
+        return String.valueOf(likeCount);
+    }
 }


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 좋아요 수를 string으로 포맷을 변경하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
1. 1000 미만일 경우, 그대로 출력
2. 1000 이상인 경우, k로 연산해주었으며 1.0K와 같은 경우를 방지하기 위해 `replace` 메서드를 사용하여 제거해주었습니다.
- .0을 제거하기 위하여 여러 방면으로 생각해보았지만, 이게 가장 깔끔한 코드인 것 같습니다. 
혹시 더 좋은 방법이 있다면 코멘트 부탁드립니다!