### PR TITLE
refactor : 회원 탈퇴 시 사유 받도록 변경

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -80,7 +80,7 @@ public class MemberController {
     @DeleteMapping("/me")
     public BaseResponseDto<MemberDeleteResponse> deleteMember(@AuthenticationPrincipal User user, @RequestBody MemberDeleteRequest memberDeleteRequest) {
         MemberDeleteResponse memberDeleteResponse
-            = memberCommandService.deleteMember(Long.parseLong(user.getUsername()), memberDeleteRequest.description());
+            = memberCommandService.deleteMember(Long.parseLong(user.getUsername()), memberDeleteRequest.content());
         return BaseResponseDto.ok(memberDeleteResponse);
     }
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.dpm.winwin.api.member.controller;
 import static com.dpm.winwin.api.common.utils.SecurityUtil.getCurrentMemberId;
 
 import com.dpm.winwin.api.common.response.dto.BaseResponseDto;
+import com.dpm.winwin.api.member.dto.request.MemberDeleteRequest;
 import com.dpm.winwin.api.member.dto.request.MemberUpdateRequest;
 import com.dpm.winwin.api.member.dto.response.MemberDeleteResponse;
 import com.dpm.winwin.api.member.dto.response.MemberNicknameResponse;
@@ -77,8 +78,9 @@ public class MemberController {
     }
 
     @DeleteMapping("/me")
-    public BaseResponseDto<MemberDeleteResponse> deleteMember(@AuthenticationPrincipal User user) {
-        MemberDeleteResponse memberDeleteResponse = memberCommandService.deleteMember(Long.parseLong(user.getUsername()));
+    public BaseResponseDto<MemberDeleteResponse> deleteMember(@AuthenticationPrincipal User user, @RequestBody MemberDeleteRequest memberDeleteRequest) {
+        MemberDeleteResponse memberDeleteResponse
+            = memberCommandService.deleteMember(Long.parseLong(user.getUsername()), memberDeleteRequest.description());
         return BaseResponseDto.ok(memberDeleteResponse);
     }
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/request/MemberDeleteRequest.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/request/MemberDeleteRequest.java
@@ -1,7 +1,7 @@
 package com.dpm.winwin.api.member.dto.request;
 
 public record MemberDeleteRequest(
-    String description
+    String content
 ) {
 
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/request/MemberDeleteRequest.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/request/MemberDeleteRequest.java
@@ -1,0 +1,7 @@
+package com.dpm.winwin.api.member.dto.request;
+
+public record MemberDeleteRequest(
+    String description
+) {
+
+}

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -119,7 +119,7 @@ public class MemberCommandService {
     }
 
     private ResponseEntity<Object> appleTokenRevokeRequest(String providerName, String refreshToken) {
-        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(providerName);
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(providerName.toLowerCase());
         String clientSecret = registration.getClientSecret();
         String clientId = registration.getClientId();
 

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -21,6 +21,7 @@ import com.dpm.winwin.domain.repository.category.SubCategoryRepository;
 import com.dpm.winwin.domain.repository.member.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -92,15 +93,12 @@ public class MemberCommandService {
         );
     }
 
-    public MemberDeleteResponse deleteMember(Long memberId) {
+    public MemberDeleteResponse deleteMember(Long memberId, String description) {
 
         Member member = memberRepository.findMemberWithToken(memberId)
             .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
 
-        OauthToken oauthToken = member.getOauthToken();
-        String refreshToken = oauthToken.getRefreshToken();
-
-        ResponseEntity<Object> response = appleTokenRevokeRequest(oauthToken.getProviderType().name(), refreshToken);
+        ResponseEntity<Object> response = revokeAppleToken(member);
 
         if (response.getStatusCode().equals(HttpStatus.OK)) {
             memberRepository.delete(member);
@@ -110,6 +108,14 @@ public class MemberCommandService {
         }
 
         throw new BusinessException(APPLE_TOKEN_REVOKE_FAIL);
+    }
+
+    @NotNull
+    private ResponseEntity<Object> revokeAppleToken(Member member) {
+        OauthToken oauthToken = member.getOauthToken();
+        String refreshToken = oauthToken.getRefreshToken();
+
+        return appleTokenRevokeRequest(oauthToken.getProviderType().name(), refreshToken);
     }
 
     private ResponseEntity<Object> appleTokenRevokeRequest(String providerName, String refreshToken) {

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -93,7 +93,7 @@ public class MemberCommandService {
         );
     }
 
-    public MemberDeleteResponse deleteMember(Long memberId, String description) {
+    public MemberDeleteResponse deleteMember(Long memberId, String content) {
 
         Member member = memberRepository.findMemberWithToken(memberId)
             .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));

--- a/winwin-be-api/src/test/java/com/dpm/winwin/api/member/controller/MemberControllerTest.java
+++ b/winwin-be-api/src/test/java/com/dpm/winwin/api/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.dpm.winwin.api.member.controller;
 
+import com.dpm.winwin.api.member.dto.request.MemberDeleteRequest;
 import com.dpm.winwin.api.member.dto.response.MemberDeleteResponse;
 import com.dpm.winwin.api.member.dto.response.MemberUpdateImageResponse;
 import com.dpm.winwin.api.member.dto.response.RanksListResponse;
@@ -295,13 +296,16 @@ public class MemberControllerTest extends RestDocsTestSupport {
         // Given
         Long deleteMemberId = Long.valueOf(MEMBER_ID);
         MemberDeleteResponse memberDeleteResponse = new MemberDeleteResponse(deleteMemberId);
-        given(memberCommandService.deleteMember(deleteMemberId)).willReturn(memberDeleteResponse);
+        String description = "탈퇴 테스트";
+        MemberDeleteRequest memberDeleteRequest = new MemberDeleteRequest(description);
+        given(memberCommandService.deleteMember(deleteMemberId, description)).willReturn(memberDeleteResponse);
 
         // Then
         ResultActions resultActions = mockMvc.perform(
             delete("/api/v1/members/me")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(memberDeleteRequest))
         );
 
         // Then


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 회원 탈퇴 시 사유 받는게 없었는데 추가하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 현재 탈퇴 사유를 받기만 하고 따로 저장하거나 사용하지 않고 있는데, 현재 회원탈퇴를 하드 딜리트로 구현 되어있는데, 이러면 굳이 사유가 필요 없을거 같아서 따로 사용하지는 않고 있습니다. 
- 프론트 개발자분들을 위해 api 형태만 우선 변경(api가 바뀐다고 앱 버전 업그레이드를 강제할 수는 없다고 들어서..)하도록 하고, 리팩토링으로 회원 탈퇴를 soft delete로 변경하면서 사유 저장하고 사용하도록 변경하겠습니다.
