### PR TITLE
feat: 랜덤 프로필 이미지 설정

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/common/file/service/AwsS3FileService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/common/file/service/AwsS3FileService.java
@@ -59,6 +59,6 @@ public class AwsS3FileService implements FileService {
     }
 
     private String getFileNameFromResourceUrl(String fileUrl) {
-        return fileUrl.replace(defaultUrl, "");
+        return fileUrl.replace(defaultUrl + "/", "");
     }
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/common/file/service/AwsS3FileService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/common/file/service/AwsS3FileService.java
@@ -1,5 +1,7 @@
 package com.dpm.winwin.api.common.file.service;
 
+import static com.dpm.winwin.api.common.constant.ImageType.PROFILE_IMAGE;
+
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -28,6 +30,9 @@ public class AwsS3FileService implements FileService {
     private String defaultUrl;
 
     public String uploadFile(MultipartFile multipartFile, Long memberId, String imageType) {
+        if (multipartFile.isEmpty()) {
+            return getDefaultRandomProfileImageUrl();
+        }
         String savedFileName = getSavedFileName(multipartFile, memberId, imageType);
         ObjectMetadata metadata = new ObjectMetadata();
 
@@ -38,6 +43,10 @@ public class AwsS3FileService implements FileService {
             throw new BusinessException(ErrorMessage.INVALID_FILE_UPLOAD);
         }
         return getResourceUrl(savedFileName);
+    }
+
+    public String getDefaultRandomProfileImageUrl() {
+        return String.format("%s/%s/%s.png", defaultUrl, PROFILE_IMAGE, (int)(Math.random() * 3 + 1));
     }
 
     public void deleteFile(String fileUrl) {

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/common/file/service/FileService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/common/file/service/FileService.java
@@ -4,5 +4,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
     String uploadFile(MultipartFile multipartFile, Long memberId, String directory);
+    String getDefaultRandomProfileImageUrl();
     void deleteFile(String fileUrl);
 }

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/oauth/service/AppleLoginService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/oauth/service/AppleLoginService.java
@@ -9,12 +9,12 @@ import static com.dpm.winwin.api.common.error.enums.ErrorMessage.MEMBER_NOT_FOUN
 import com.dpm.winwin.api.common.error.exception.custom.AppleTokenGenerateException;
 import com.dpm.winwin.api.common.error.exception.custom.BusinessException;
 import com.dpm.winwin.api.common.error.exception.custom.InvalidIdTokenException;
+import com.dpm.winwin.api.common.file.service.FileService;
 import com.dpm.winwin.api.configuration.NicknameGenerator;
 import com.dpm.winwin.api.jwt.TokenProvider;
 import com.dpm.winwin.api.jwt.TokenResponse;
 import com.dpm.winwin.api.oauth.dto.ApplePublicKeys;
 import com.dpm.winwin.api.oauth.dto.AppleToken;
-import com.dpm.winwin.api.oauth.dto.MemberInfo;
 import com.dpm.winwin.domain.entity.member.Member;
 import com.dpm.winwin.domain.entity.member.enums.ProviderType;
 import com.dpm.winwin.domain.entity.member.enums.Ranks;
@@ -24,7 +24,6 @@ import com.dpm.winwin.domain.repository.member.MemberRepository;
 import com.dpm.winwin.domain.repository.oauth.OauthRepository;
 import com.dpm.winwin.domain.repository.token.JwtTokenRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.SignedJWT;
 import io.jsonwebtoken.Claims;
@@ -67,6 +66,7 @@ public class AppleLoginService {
     private final RestTemplate restTemplate;
     private final OauthRepository oauthRepository;
     private final NicknameGenerator nicknameGenerator;
+    private final FileService fileService;
     private static final String APPLE_BASE_URL = "https://appleid.apple.com";
     private static final String APPLE_TOKEN_REQUEST_URL = APPLE_BASE_URL + "/auth/token";
 
@@ -98,7 +98,7 @@ public class AppleLoginService {
     }
 
     private Member saveMember(String nickname){
-        Member newMember = new Member(nickname, Ranks.ROOKIE);
+        Member newMember = new Member(nickname, fileService.getDefaultRandomProfileImageUrl(), Ranks.ROOKIE);
         return memberRepository.save(newMember);
     }
 

--- a/winwin-be-api/src/main/resources/application-dev.yml
+++ b/winwin-be-api/src/main/resources/application-dev.yml
@@ -79,7 +79,7 @@ cloud:
     s3:
       bucket:
         name: ENC(KydYPKGs+Dt6Tw5ftB3q9KZzx6elxYBe2103TDNwZvA=)
-        url: ENC(euVI7Jo0kFw7UqVivAr7EuROccDHvzE9jNjei3mYt49yAal3CRP2iErcbW90Fjm2gM8IhjxVYCY80JHdUcX+pLxiTB2uWnUr)
+        url: ENC(L2/sKyfUZeKtBpurGc2nEPWV4fgk8V3uDowE61AXeTLugcoWjy7t2ERNjAK5JjZ0B7kPKaD6SHP6LjdOc6GGwGM/Y5LqR+FT)
 
     credentials:
       access-key: ENC(RKFCNH3Hfh23NDkdV9qcBQFY05KOWokFk3WqUIDgckQ=)

--- a/winwin-be-api/src/main/resources/application-local.yml
+++ b/winwin-be-api/src/main/resources/application-local.yml
@@ -81,7 +81,7 @@ cloud:
     s3:
       bucket:
         name: ENC(KydYPKGs+Dt6Tw5ftB3q9KZzx6elxYBe2103TDNwZvA=)
-        url: ENC(euVI7Jo0kFw7UqVivAr7EuROccDHvzE9jNjei3mYt49yAal3CRP2iErcbW90Fjm2gM8IhjxVYCY80JHdUcX+pLxiTB2uWnUr)
+        url: ENC(L2/sKyfUZeKtBpurGc2nEPWV4fgk8V3uDowE61AXeTLugcoWjy7t2ERNjAK5JjZ0B7kPKaD6SHP6LjdOc6GGwGM/Y5LqR+FT)
 
     credentials:
       access-key: ENC(RKFCNH3Hfh23NDkdV9qcBQFY05KOWokFk3WqUIDgckQ=)

--- a/winwin-be-api/src/main/resources/application-prod.yml
+++ b/winwin-be-api/src/main/resources/application-prod.yml
@@ -80,7 +80,7 @@ cloud:
     s3:
       bucket:
         name: ENC(KydYPKGs+Dt6Tw5ftB3q9KZzx6elxYBe2103TDNwZvA=)
-        url: ENC(euVI7Jo0kFw7UqVivAr7EuROccDHvzE9jNjei3mYt49yAal3CRP2iErcbW90Fjm2gM8IhjxVYCY80JHdUcX+pLxiTB2uWnUr)
+        url: ENC(L2/sKyfUZeKtBpurGc2nEPWV4fgk8V3uDowE61AXeTLugcoWjy7t2ERNjAK5JjZ0B7kPKaD6SHP6LjdOc6GGwGM/Y5LqR+FT)
 
     credentials:
       access-key: ENC(RKFCNH3Hfh23NDkdV9qcBQFY05KOWokFk3WqUIDgckQ=)

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/member/Member.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/member/Member.java
@@ -70,9 +70,10 @@ public class Member extends BaseEntity{
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.REMOVE)
     private OauthToken oauthToken;
 
-    public Member(String nickname, Ranks ranks) {
+    public Member(String nickname, String image, Ranks ranks) {
         this.nickname = nickname;
         this.ranks = ranks;
+        this.image = image;
         this.likeCount = 0;
     }
 


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 회원 가입, 프로필 이미지 업데이트 시에 랜덤 프로필 이미지가 db에 저장되도록 설정하였습니다.
- properties에 `cloud.aws.s3.bucket.url`를 `url경로/` -> `url경로`로 변경해주었습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 회원 가입 시, 이미지를 설정하지 않은 상태로 종료하고 접속했을 경우를 대비하여 회원 가입 시에도 랜덤 이미지를 설정해 주었습니다.

새해 복 많이 받으세요 🦄🎉🎇🎀🎁🧚👨‍👩‍👦‍👦🤼🥳
코멘트와 어프루브는 언제나 제게 힘이 됩니다 😉