### PR TITLE
refactor : 회원 탈퇴 시 게시글 함께 삭제되도록 변경

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/configuration/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/configuration/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -31,9 +31,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
         HttpServletResponse response) {
         log.info("==== saveAuthorizationRequest ====");
-        String userAgent = request.getHeader("user-agent");
-        log.info("userAgent =====>  {}", userAgent);
-
         if (authorizationRequest == null) {
             log.info("쿠키 삭제");
             CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberCommandService.java
@@ -21,6 +21,7 @@ import com.dpm.winwin.domain.repository.category.SubCategoryRepository;
 import com.dpm.winwin.domain.repository.member.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,6 +37,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 @Transactional
@@ -98,6 +100,7 @@ public class MemberCommandService {
         Member member = memberRepository.findMemberWithToken(memberId)
             .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
 
+        log.info("member : {}", member);
         ResponseEntity<Object> response = revokeAppleToken(member);
 
         if (response.getStatusCode().equals(HttpStatus.OK)) {

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/member/Member.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/entity/member/Member.java
@@ -43,13 +43,13 @@ public class Member extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "host")
+    @OneToMany(mappedBy = "host", cascade = CascadeType.REMOVE)
     private final List<ChatRoom> chatRooms = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberTalent> talents = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<Post> posts = new ArrayList<>();
 
     @Column(nullable = false)


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 회원 탈퇴 시 게시글도 함께 삭제되도록 변경하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 회원 탈퇴 시 작성했던 게시글이 있으면 해당 회원을 참조하고 있는 테이블이 존재해서 `ConstraintViolationException` 이 발생합니다.
```
Cannot delete or update a parent row: a foreign key constraint fails (`winwin`.`post`, CONSTRAINT `FK83s99f4kx8oiqm3ro0sasmpww` FOREIGN KEY (`member_id`) REFERENCES `member` (`id`))
```
이런 익셉션이 발생하여 회원 탈퇴 시 게시글도 함께 삭제되도록 했습니다.