### PR TITLE
refactor : 사용자 조회 시 애플에서 제공해준 이름도 응답 데이터에 추가

### DIFF
--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberRankReadResponse.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/dto/response/MemberRankReadResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record MemberRankReadResponse(
         Long memberId,
+        String name,
         String nickname,
         String image,
         String introduction,

--- a/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberQueryService.java
+++ b/winwin-be-api/src/main/java/com/dpm/winwin/api/member/service/MemberQueryService.java
@@ -47,6 +47,7 @@ public class MemberQueryService {
 
         return new MemberRankReadResponse(
                 memberReadResponse.memberId(),
+                memberReadResponse.name(),
                 memberReadResponse.nickname(),
                 memberReadResponse.image(),
                 memberReadResponse.introduction(),

--- a/winwin-be-api/src/test/java/com/dpm/winwin/api/member/controller/MemberControllerTest.java
+++ b/winwin-be-api/src/test/java/com/dpm/winwin/api/member/controller/MemberControllerTest.java
@@ -202,6 +202,7 @@ public class MemberControllerTest extends RestDocsTestSupport {
 
         when(memberQueryService.readMemberInfo(any())).thenReturn(new MemberRankReadResponse(
                 1L,
+                "홍길동",
                 "김감자",
                 "https://dpm-pingpong-bucket.s3.ap-northeast-2.amazonaws.com/profileImage/3d4395e461db40108104200e286870c4-kirby.png",
                 "안녕하세요 김감자입니다.",
@@ -229,6 +230,8 @@ public class MemberControllerTest extends RestDocsTestSupport {
                                                 .description("성공 여부"),
                                         fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
                                                 .description("저장된 회원 id"),
+                                        fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                                .description("유저 이름"),
                                         fieldWithPath("data.nickname").type(JsonFieldType.STRING)
                                                 .description("닉네임"),
                                         fieldWithPath("data.image").type(JsonFieldType.STRING)

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/dto/response/MemberReadResponse.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/dto/response/MemberReadResponse.java
@@ -3,6 +3,7 @@ package com.dpm.winwin.domain.repository.member.dto.response;
 import com.dpm.winwin.domain.entity.member.enums.Ranks;
 
 public record MemberReadResponse(Long memberId,
+                                 String name,
                                  String nickname,
                                  String image,
                                  String introduction,

--- a/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/impl/CustomMemberRepositoryImpl.java
+++ b/winwin-be-domain/src/main/java/com/dpm/winwin/domain/repository/member/impl/CustomMemberRepositoryImpl.java
@@ -31,6 +31,7 @@ public class CustomMemberRepositoryImpl implements CustomMemberRepository {
                                         Projections.constructor(
                                                 MemberReadResponse.class,
                                                 member.id,
+                                                member.name,
                                                 member.nickname,
                                                 member.image,
                                                 member.introduction,


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 사용자 조회 시 애플에서 제공해준 이름 응답 데이터에 추가하도록 수정했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
